### PR TITLE
Automatic release workflow completed

### DIFF
--- a/.github/workflows/helper.py
+++ b/.github/workflows/helper.py
@@ -1,7 +1,7 @@
 import argparse
 import re
 import os
-def create_new_tag(tag):
+def create_new_tag(tag, update_major):
     if not (re.match(r'^v\d+\.\d+$', tag)):
         raise Exception(f'tag: {tag} is not giving in the correct format e.i v0.0')
     
@@ -11,8 +11,15 @@ def create_new_tag(tag):
     if len(digits_tags) != 2:
         raise Exception(f'tag: {tag} must contain two version digits')
     
-    new_digit = int(digits_tags[1]) + 1
-    return "v" + str(digits_tags[0]) + "." + str(new_digit)
+    major_num = int(digits_tags[0])
+    minor_num = int(digits_tags[1])
+    if update_major:
+        print(f"Label detected to update major version")
+        major_num += 1
+        minor_num = 0
+    else:
+        minor_num += 1
+    return f"v{major_num}.{minor_num}"
 
 def store_tag(tag):
     with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
@@ -24,7 +31,6 @@ def update_file_with_tag(f_name, old_tag, new_tag):
             with open(f_name, "r",encoding="utf-8") as f:
                 data = f.read()
             data = data.replace(old_tag, new_tag)
-
             with open(f_name, "w",encoding="utf-8") as f:
                 f.write(data)
         except Exception as e:
@@ -38,7 +44,7 @@ def main(args):
     if not tag:
         print(f"Warning: a latest release with a tag does not exist in current repository, starting from {new_tag}")
     else:
-        new_tag = create_new_tag(tag)
+        new_tag = create_new_tag(tag,args.update_major_ver)
         print(f"Repository with tag: {tag}, creating a new tag with: {new_tag}")
         update_file_with_tag(".zenodo.json", tag, new_tag)
         update_file_with_tag("CITATION.cff", tag, new_tag)
@@ -49,11 +55,28 @@ def run():
     args = parser.parse_args()
     main(args)
 
+
+def str_to_bool(value):
+    if value.lower() == "true":
+        return True
+    elif value.lower() == "false":
+        return False
+    else:
+        raise Exception(
+            f"Error: value {value} as argument is not accepted\n"
+            f"retry with true or false"
+        )
+    
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--tag", type=str,
         help="Require: latest tag",
+        required=True
+    )
+    parser.add_argument(
+        "--update_major_ver", type=str_to_bool,
+        help="Require: boolean to update the major tag number",
         required=True
     )
     run()

--- a/.github/workflows/helper.py
+++ b/.github/workflows/helper.py
@@ -18,17 +18,12 @@ def store_tag(tag):
     with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
         print(f'new_tag={tag}', file=fh)
 
-#TO-DO: decide between regex or replace with old tag
-#       if regex remove extra param old_tag
-#       if replace func then remove regex instruction 
 def update_file_with_tag(f_name, old_tag, new_tag):
     if os.path.isfile(f_name):
         try:
             with open(f_name, "r",encoding="utf-8") as f:
                 data = f.read()
-            # data = data.replace(old_tag, new_tag)
-            # data = re.sub(r'v\d+((\.\d+)+)', new_tag,data)
-            data = re.sub(r'v\d+\.(\d+\.\d+|\d+)', new_tag,data)
+            data = data.replace(old_tag, new_tag)
             with open(f_name, "w",encoding="utf-8") as f:
                 f.write(data)
         except Exception as e:

--- a/.github/workflows/helper.py
+++ b/.github/workflows/helper.py
@@ -24,6 +24,7 @@ def update_file_with_tag(f_name, old_tag, new_tag):
             with open(f_name, "r",encoding="utf-8") as f:
                 data = f.read()
             data = data.replace(old_tag, new_tag)
+
             with open(f_name, "w",encoding="utf-8") as f:
                 f.write(data)
         except Exception as e:
@@ -41,6 +42,7 @@ def main(args):
         print(f"Repository with tag: {tag}, creating a new tag with: {new_tag}")
         update_file_with_tag(".zenodo.json", tag, new_tag)
         update_file_with_tag("CITATION.cff", tag, new_tag)
+        update_file_with_tag("README.md", tag, new_tag)
     store_tag(new_tag)
 
 def run():

--- a/.github/workflows/helper.py
+++ b/.github/workflows/helper.py
@@ -1,14 +1,13 @@
-import json
 import argparse
 import re
 import os
 def create_new_tag(tag):
-    if not (re.match(r'^v\d', tag)):
+    if not (re.match(r'^v\d+\.\d+$', tag)):
         raise Exception(f'tag: {tag} is not giving in the correct format e.i v0.0')
     
-    # Notice that this will make tag version of three digits become two digits
+    # Notice that this could make a tag version of three digits become two digits
     # e.i 3.2.1 -> 3.3
-    digits_tags = (re.match(r'^v\d+.\d+', tag)).group()[1::].split('.')
+    digits_tags = (re.match(r'^v\d+\.\d+', tag)).group()[1::].split('.')
     if len(digits_tags) != 2:
         raise Exception(f'tag: {tag} must contain two version digits')
     
@@ -19,33 +18,23 @@ def store_tag(tag):
     with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
         print(f'new_tag={tag}', file=fh)
 
-def update_files_with_tag(old_tag, new_tag):
-    # This function needs to take care of updating 
-    # .zenodo.json and CITATION.cff
-    # TO-DO: make zenodo.json robust to search for version tags
-    if os.path.isfile(".zenodo.json"):
+#TO-DO: decide between regex or replace with old tag
+#       if regex remove extra param old_tag
+#       if replace func then remove regex instruction 
+def update_file_with_tag(f_name, old_tag, new_tag):
+    if os.path.isfile(f_name):
         try:
-            with open(".zenodo.json", "r") as f:
-                data = json.load(f)
-
-            data["version"] = data["version"].replace(old_tag,new_tag)
-            data["title"] = data["title"].replace(old_tag,new_tag)
-
-            with open(".zenodo.json", "w") as f:
-                json.dump(data, f)
-            
+            with open(f_name, "r",encoding="utf-8") as f:
+                data = f.read()
+            # data = data.replace(old_tag, new_tag)
+            # data = re.sub(r'v\d+((\.\d+)+)', new_tag,data)
+            data = re.sub(r'v\d+\.(\d+\.\d+|\d+)', new_tag,data)
+            with open(f_name, "w",encoding="utf-8") as f:
+                f.write(data)
         except Exception as e:
             print(e)
-
-    if os.path.isfile("CITATION.cff"):
-        try:
-            with open("CITATION.cff", "r", encoding="utf-8") as file:
-                citation = file.read()
-            modified_citation = citation.replace(old_tag, new_tag)
-            with open("CITATION.cff", "w", encoding="utf-8") as file:
-                file.write(modified_citation)                
-        except Exception as e:
-            print(e)
+    else:
+        print(f"Warning: {f_name} doest exist at the current path {os.getcwd()}")
 
 def main(args):
     tag = args.tag
@@ -55,7 +44,8 @@ def main(args):
     else:
         new_tag = create_new_tag(tag)
         print(f"Repository with tag: {tag}, creating a new tag with: {new_tag}")
-        update_files_with_tag(tag,new_tag)
+        update_file_with_tag(".zenodo.json", tag, new_tag)
+        update_file_with_tag("CITATION.cff", tag, new_tag)
     store_tag(new_tag)
 
 def run():

--- a/.github/workflows/version_release.yml
+++ b/.github/workflows/version_release.yml
@@ -13,8 +13,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.MS3_BOT_TOKEN }}
-      
-          # this step could be replaced with dcml_docker action
+
       - name: "Get ms3 package & transform"
         id: tag
         continue-on-error: true
@@ -24,45 +23,34 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ secrets.MS3_BOT_TOKEN }}
 
-      # this step could be replaced with dcml_docker action
-      - name: Setup Github credentials
-        run: |
-          git config --global user.name "ms3-bot"
-          git config --global user.email dcml.annotators@epfl.ch
-
       - name: "Generate new tag version"
         id: generate_tag
         run: |
-            ls -a
             python .github/workflows/helper.py --tag "${{ steps.tag.outputs.tag_version }}"
-            ls -a
-            cat .zenodo.json
 
-      # this step could be replaced with dcml_docker action
-      - name: "Get ms3 package & transform"
+      - name: Setup Github credentials & push zenodo and citation changes
+        continue-on-error: true
+        run: |
+          git config --global user.name "ms3-bot"
+          git config --global user.email dcml.annotators@epfl.ch
+          git add .zenodo.json CITATION.cff
+          git commit -m 'chore: zenodo and citation files updated with tag: ${{ steps.generate_tag.outputs.new_tag }}'
+          git push
+    
+      # TO-DO: decide whether results of ms3 transform needs to be pushed to repository
+      - name: "Get ms3 package & apply transform"
         run: |
             pip install --upgrade pip
             pip install ms3
-            ls -a
             ms3 transform -M -N -X -F -D
-            ls -a
 
-      - name: "Create release"
-        uses: "marvinpinto/action-automatic-releases@latest"
+      - uses: ncipollo/release-action@v1
         with:
-          repo_token: "${{ secrets.MS3_BOT_TOKEN }}"
-          automatic_release_tag: "${{ steps.generate_tag.outputs.new_tag }}"
-          prerelease: false
-          title: "${{ github.event.pull_request.title }}"
-          files: |
-            .zenodo.json
-            CITATION.cff
-            ${{ github.event.repository.name }}.zip
-            ${{ github.event.repository.name }}.datapackage.json
-            abc.datapackage.json.errors
-
-      - name: "Update release body"
-        run: |
-          gh release edit "${{ steps.generate_tag.outputs.new_tag }}" --notes "${{ github.event.pull_request.body }}" --repo "${{ github.event.repository.full_name }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.MS3_BOT_TOKEN }}     
+          artifacts: "${{ github.event.repository.name }}.zip,\
+                      ${{ github.event.repository.name }}.datapackage.json,\
+                      ${{ github.event.repository.name }}.datapackage.errors"
+          body: "${{ github.event.pull_request.body }}"
+          name: "${{ github.event.pull_request.title }}"
+          tag: "${{ steps.generate_tag.outputs.new_tag }}"
+          makeLatest: "latest"
+          commit: "${{ github.event.pull_request.base.ref }}"

--- a/.github/workflows/version_release.yml
+++ b/.github/workflows/version_release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.MS3_BOT_TOKEN }}
-
+          ref: "${{ github.event.pull_request.base.ref }}"
       - name: "Get ms3 package & transform"
         id: tag
         continue-on-error: true
@@ -37,7 +37,6 @@ jobs:
           git commit -m 'chore: zenodo and citation files updated with tag: ${{ steps.generate_tag.outputs.new_tag }}'
           git push
     
-      # TO-DO: decide whether results of ms3 transform needs to be pushed to repository
       - name: "Get ms3 package & apply transform"
         run: |
             pip install --upgrade pip

--- a/.github/workflows/version_release.yml
+++ b/.github/workflows/version_release.yml
@@ -12,21 +12,24 @@ jobs:
       - name: Checkout corpus repository
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           token: ${{ secrets.MS3_BOT_TOKEN }}
           ref: "${{ github.event.pull_request.base.ref }}"
-      - name: "Get ms3 package & transform"
+
+      - name: "Get latest tag version"
         id: tag
         continue-on-error: true
         run: |
-            res=$(gh api -H "Accept: application/vnd.github+json" repos/${{ github.event.repository.full_name }}/releases/latest --jq '.tag_name')
+            res=$(git tag -l --sort=-v:refname | grep --invert-match '\^' | head -n 1)
             echo "tag_version=${res}" >> $GITHUB_OUTPUT
         env:
             GITHUB_TOKEN: ${{ secrets.MS3_BOT_TOKEN }}
 
-      - name: "Generate new tag version"
+      - name: "Generate a new tag version"
         id: generate_tag
         run: |
-            python .github/workflows/helper.py --tag "${{ steps.tag.outputs.tag_version }}"
+            major_in_PR="${{ contains(github.event.pull_request.labels.*.name, 'major_version')}}"
+            python .github/workflows/helper.py --tag "${{ steps.tag.outputs.tag_version }}" --update_major_ver "$major_in_PR"
 
       - name: Setup Github credentials & push zenodo, citation and README changes
         continue-on-error: true
@@ -46,6 +49,7 @@ jobs:
           git push
     
       - name: "Get ms3 package & apply transform"
+        continue-on-error: true
         run: |
             pip install --upgrade pip
             pip install ms3

--- a/.github/workflows/version_release.yml
+++ b/.github/workflows/version_release.yml
@@ -28,13 +28,21 @@ jobs:
         run: |
             python .github/workflows/helper.py --tag "${{ steps.tag.outputs.tag_version }}"
 
-      - name: Setup Github credentials & push zenodo and citation changes
+      - name: Setup Github credentials & push zenodo, citation and README changes
         continue-on-error: true
         run: |
           git config --global user.name "ms3-bot"
           git config --global user.email dcml.annotators@epfl.ch
-          git add .zenodo.json CITATION.cff
-          git commit -m 'chore: zenodo and citation files updated with tag: ${{ steps.generate_tag.outputs.new_tag }}'
+          if [[ -f .zenodo.json ]]; then
+            git add .zenodo.json
+          fi
+          if [[ -f CITATION.cff ]]; then
+            git add CITATION.cff
+          fi
+          if [[ -f README.md ]]; then
+            git add README.md
+          fi          
+          git commit -m 'chore: files updated with tag: ${{ steps.generate_tag.outputs.new_tag }}'
           git push
     
       - name: "Get ms3 package & apply transform"


### PR DESCRIPTION
Hi @johentsch, after taking in consideration the feedback. I think this version could be merged to the main branch. Nevertheless, There are couple of things that needs to be mentioned for this PR: 

- Rather than using the https://github.com/marketplace/actions/automatic-releases, I swapped the action with  https://github.com/marketplace/actions/create-release, the main reason for this decision is that automatic releases requires some changes to its source,  there has not been much support for two years, and the mechanism to create the action in the marketplace is a bit ambiguous. 

- For the zenodo and citation files, there are two ways in which we could replace the tags, which one would you prefer?
  - The old tag is used to replace strings in the files 
   - Using a regex with pattern ```v\d+\.(\d+\.\d+|\d+)``` to replace strings in the files
   
   Notice: the advantage of using regex is that for any string version which is not the latest tag, these will still update with the new tag

- It does not seem possible to update the zenodo and citation files when the PR is being merged, a simple solution is to push these changes to the main branch once the PR is merged, what do you think about this? 

- When applying transform, should we commit and push the generated files ?