### PR TITLE
fix: version_release clones submodules to generate packages in release

### DIFF
--- a/.github/workflows/version_release.yml
+++ b/.github/workflows/version_release.yml
@@ -15,7 +15,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.MS3_BOT_TOKEN }}
           ref: "${{ github.event.pull_request.base.ref }}"
-
+          submodules: recursive
+          
       - name: "Get latest tag version"
         id: tag
         continue-on-error: true


### PR DESCRIPTION
PR has the following modification:

- Step ```Checkout corpus repository``` in version_release.yml includes flag ```submodules: recursive```